### PR TITLE
[Flutter] - Convert code components to Markdown fences

### DIFF
--- a/src/content/docs/flutter/common-issues-debugging.mdx
+++ b/src/content/docs/flutter/common-issues-debugging.mdx
@@ -31,7 +31,8 @@ State management problems often manifest as inefficient UI updates, leading to p
 
 Use debug prints and the Widget Inspector to identify which widgets are rebuilding and how often. This helps pinpoint inefficiencies in your widget tree.
 
-<Code code={`// Add debug prints to track widget rebuilds
+```dart title="Tracking Rebuilds"
+// Add debug prints to track widget rebuilds
 import 'package:flutter/foundation.dart';
 
 class MyWidget extends StatelessWidget {
@@ -45,13 +46,14 @@ class MyWidget extends StatelessWidget {
     return Consumer<MyDataModel>(
       builder: (context, model, child) {
         // Track Consumer rebuilds with data changes
-        debugPrint('Consumer rebuilding with: \${model.someValue}');
+        debugPrint('Consumer rebuilding with: ${model.someValue}');
         
         return Text(model.someValue);
       },
     );
   }
-}`} lang="dart" title="Tracking Rebuilds" />
+}
+```
 
 <Aside type="note">
   **Widget Inspector**: Use Flutter DevTools' Widget Inspector to visualize rebuild boundaries and identify which parts of your widget tree are rebuilding.
@@ -61,7 +63,8 @@ class MyWidget extends StatelessWidget {
 
 Enable Flutter's performance overlay to see real-time performance metrics directly on your device screen.
 
-<Code code={`// Enable performance overlay in your app
+```dart title="Performance Overlay"
+// Enable performance overlay in your app
 import 'package:flutter/material.dart';
 
 void main() {
@@ -73,7 +76,8 @@ void main() {
       home: MyApp(),
     ),
   );
-}`} lang="dart" title="Performance Overlay" />
+}
+```
 
 ---
 
@@ -87,7 +91,8 @@ The key to efficient state management is isolating state changes to the smallest
   <TabItem label="Problem">
     **Rebuilding Too Much**: When state is placed too high in the widget tree, changing it causes unnecessary rebuilds of all child widgets.
 
-    <Code code={`// BAD: Entire screen rebuilds for a small counter change
+```dart
+// BAD: Entire screen rebuilds for a small counter change
 class CounterScreen extends StatefulWidget {
   @override
   _CounterScreenState createState() => _CounterScreenState();
@@ -102,7 +107,7 @@ class _CounterScreenState extends State<CounterScreen> {
       body: Column(
         children: [
           ExpensiveWidget(),  // Rebuilds unnecessarily!
-          Text('Count: \$_counter'),
+          Text('Count: $_counter'),
           ElevatedButton(
             onPressed: () => setState(() => _counter++),
             child: const Text('Increment'),
@@ -111,13 +116,15 @@ class _CounterScreenState extends State<CounterScreen> {
       ),
     );
   }
-}`} lang="dart" />
+}
+```
   </TabItem>
 
   <TabItem label="Solution">
     **Isolate State**: Move state down to the smallest widget that needs it, preventing unnecessary rebuilds of sibling widgets.
 
-    <Code code={`// GOOD: Only the counter widget rebuilds
+```dart
+// GOOD: Only the counter widget rebuilds
 class CounterScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -144,7 +151,7 @@ class _CounterWidgetState extends State<CounterWidget> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Text('Count: \$_counter'),
+        Text('Count: $_counter'),
         ElevatedButton(
           onPressed: () => setState(() => _counter++),
           child: const Text('Increment'),
@@ -152,7 +159,8 @@ class _CounterWidgetState extends State<CounterWidget> {
       ],
     );
   }
-}`} lang="dart" />
+}
+```
   </TabItem>
 </Tabs>
 
@@ -160,7 +168,8 @@ class _CounterWidgetState extends State<CounterWidget> {
 
 For even more fine-grained control, use `ValueNotifier` to update only specific parts of the UI without rebuilding parent widgets.
 
-<Code code={`// ValueListenableBuilder updates only when the ValueNotifier changes
+```dart title="Selection Model Pattern"
+// ValueListenableBuilder updates only when the ValueNotifier changes
 class SelectableListItem extends StatelessWidget {
   final String title;
   final String id;
@@ -216,7 +225,8 @@ class SelectionModel extends ChangeNotifier {
     
     notifyListeners();
   }
-}`} lang="dart" title="Selection Model Pattern" />
+}
+```
 
 ---
 
@@ -228,14 +238,16 @@ Layout overflows occur when widgets attempt to render outside their allocated bo
 
 Enable debug painting to visualize widget boundaries and understand layout constraints:
 
-<Code code={`// Enable debug painting to visualize layout bounds
+```dart title="Debug Painting"
+// Enable debug painting to visualize layout bounds
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show debugPaintSizeEnabled;
 
 void main() {
   debugPaintSizeEnabled = true;  // Shows widget boundaries with borders
   runApp(MyApp());
-}`} lang="dart" title="Debug Painting" />
+}
+```
 
 ### Common Overflow Solutions
 
@@ -243,7 +255,8 @@ void main() {
   <TabItem label="Row/Column">
     **Text Overflow in Rows**: Text widgets in rows need explicit constraints to handle overflow properly.
 
-    <Code code={`// PROBLEM: Text overflows in Row
+```dart
+// PROBLEM: Text overflows in Row
 Row(
   children: [
     Icon(Icons.account_circle),
@@ -272,13 +285,15 @@ Row(
       ),
     ),
   ],
-)`} lang="dart" />
+)
+```
   </TabItem>
 
   <TabItem label="ListView">
     **ListView in Column**: ListView has unbounded height by default, which causes overflow in a Column.
 
-    <Code code={`// PROBLEM: ListView in Column
+```dart
+// PROBLEM: ListView in Column
 Column(
   children: [
     Text('Header'),
@@ -320,13 +335,15 @@ Column(
     ),
     Text('Footer'),
   ],
-)`} lang="dart" />
+)
+```
   </TabItem>
 
   <TabItem label="Text">
     **Text Overflow Handling**: Control how text behaves when it doesn't fit in its container.
 
-    <Code code={`// PROBLEM: Text overflows container
+```dart
+// PROBLEM: Text overflows container
 Container(
   width: 100,
   child: Text('This long text will overflow'),
@@ -358,7 +375,8 @@ Container(
     fit: BoxFit.scaleDown,  // Scales text to fit
     child: Text('This text scales down'),
   ),
-)`} lang="dart" />
+)
+```
   </TabItem>
 </Tabs>
 
@@ -366,7 +384,8 @@ Container(
 
 Use `LayoutBuilder` to adapt your UI based on available space and prevent overflow issues:
 
-<Code code={`// Adapt layout based on available space
+```dart title="Responsive Layouts"
+// Adapt layout based on available space
 LayoutBuilder(
   builder: (BuildContext context, BoxConstraints constraints) {
     // Choose layout based on width
@@ -396,7 +415,8 @@ LayoutBuilder(
       ),
     );
   },
-)`} lang="dart" title="Responsive Layouts" />
+)
+```
 
 <Aside type="tip">
   **Layout Explorer**: Use Flutter DevTools' Layout Explorer to visualize widget constraints and understand positioning and sizing decisions.
@@ -436,7 +456,8 @@ Flutter DevTools provides comprehensive profiling capabilities to identify perfo
 
 Create a custom widget to track rebuild performance in specific parts of your app:
 
-<Code code={`// Track rebuild times for specific widgets
+```dart title="Rebuild Tracker"
+// Track rebuild times for specific widgets
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
@@ -476,37 +497,41 @@ class _RebuildTrackerState extends State<RebuildTracker> {
     // Log performance data
     if (_buildCount % 10 == 0 || _stopwatch.elapsedMilliseconds > 16) {
       debugPrint(
-        '[PERF] \${widget.name} rebuilt \$_buildCount times. '
-        'Last build: \${_stopwatch.elapsedMilliseconds}ms'
+        '[PERF] ${widget.name} rebuilt $_buildCount times. '
+        'Last build: ${_stopwatch.elapsedMilliseconds}ms'
       );
     }
     
     _stopwatch.reset();
     return result;
   }
-}`} lang="dart" title="Rebuild Tracker" />
+}
+```
 
 **Usage example:**
 
-<Code code={`// Wrap widgets to track their rebuild performance
+```dart title="Using Rebuild Tracker"
+// Wrap widgets to track their rebuild performance
 RebuildTracker(
   name: 'ProductList',
   child: ListView.builder(
     itemCount: products.length,
     itemBuilder: (context, index) {
       return RebuildTracker(
-        name: 'ProductItem \$index',
+        name: 'ProductItem $index',
         child: ProductItem(product: products[index]),
       );
     },
   ),
-)`} lang="dart" title="Using Rebuild Tracker" />
+)
+```
 
 ### Memory Leak Prevention
 
 Always dispose of resources properly to prevent memory leaks:
 
-<Code code={`// Properly dispose resources to prevent memory leaks
+```dart title="Resource Disposal"
+// Properly dispose resources to prevent memory leaks
 class _MyWidgetState extends State<MyWidget> {
   late StreamSubscription _subscription;
   late AnimationController _controller;
@@ -526,7 +551,8 @@ class _MyWidgetState extends State<MyWidget> {
     _controller.dispose();
     super.dispose();  // Always call super.dispose() last
   }
-}`} lang="dart" title="Resource Disposal" />
+}
+```
 
 <Aside type="tip">
   **Memory Snapshots**: Use DevTools' Memory page to take snapshots and identify memory leaks. Look for objects that persist unexpectedly or steadily increasing memory usage.
@@ -544,7 +570,8 @@ Minimize rebuilds to improve performance and create a smoother user experience.
   <TabItem label="Const Constructors">
     **Use Const for Static Widgets**: Const constructors create compile-time constants that are reused across builds, reducing memory allocations.
 
-    <Code code={`// BAD: Creates new widgets on every build
+```dart
+// BAD: Creates new widgets on every build
 Widget build(BuildContext context) {
   return Container(
     padding: EdgeInsets.all(16.0),
@@ -558,15 +585,17 @@ Widget build(BuildContext context) {
     padding: EdgeInsets.all(16.0),
     child: Icon(Icons.star),
   );
-}`} lang="dart" />
+}
+```
 
-    **When to use**: Widgets that don't depend on runtime data and never change.
+**When to use**: Widgets that don't depend on runtime data and never change.
   </TabItem>
   
   <TabItem label="ValueNotifier">
     **Granular Updates with ValueNotifier**: Update only specific parts of the UI without rebuilding parent widgets.
 
-    <Code code={`// ValueNotifier for fine-grained control
+```dart
+// ValueNotifier for fine-grained control
 class CounterWidget extends StatelessWidget {
   final ValueNotifier<int> _counter = ValueNotifier<int>(0);
   
@@ -580,7 +609,7 @@ class CounterWidget extends StatelessWidget {
         ValueListenableBuilder<int>(
           valueListenable: _counter,
           builder: (context, value, child) {
-            return Text('Count: \$value');
+            return Text('Count: $value');
           },
         ),
         
@@ -591,15 +620,17 @@ class CounterWidget extends StatelessWidget {
       ],
     );
   }
-}`} lang="dart" />
+}
+```
 
-    **When to use**: Simple, localized state updates without external state management.
+**When to use**: Simple, localized state updates without external state management.
   </TabItem>
   
   <TabItem label="RepaintBoundary">
     **Isolate Painting Operations**: Use `RepaintBoundary` to prevent unnecessary repaints of expensive widgets.
 
-    <Code code={`// Isolate painting for independent animations
+```dart
+// Isolate painting for independent animations
 class MyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -617,13 +648,14 @@ class MyWidget extends StatelessWidget {
       ],
     );
   }
-}`} lang="dart" />
+}
+```
 
-    **When to use**: Complex animations, expensive renders, or independently updating widgets.
-    
-    <Aside type="caution">
-      Excessive use of RepaintBoundary can increase memory usage. Use it strategically for truly expensive operations.
-    </Aside>
+**When to use**: Complex animations, expensive renders, or independently updating widgets.
+
+<Aside type="caution">
+  Excessive use of RepaintBoundary can increase memory usage. Use it strategically for truly expensive operations.
+</Aside>
   </TabItem>
 </Tabs>
 
@@ -631,7 +663,8 @@ class MyWidget extends StatelessWidget {
 
 Use lazy loading and proper keys to optimize list performance:
 
-<Code code={`// Use ListView.builder for efficient lazy loading
+```dart title="List Optimization"
+// Use ListView.builder for efficient lazy loading
 ListView.builder(
   itemCount: items.length,
   itemBuilder: (context, index) {
@@ -664,13 +697,15 @@ ListView.builder(
       title: Text(item.title),
     );
   },
-)`} lang="dart" title="List Optimization" />
+)
+```
 
 ### Heavy Computation Strategies
 
 Move expensive operations off the main thread using isolates:
 
-<Code code={`// Using compute for simpler background processing
+```dart title="Compute Function"
+// Using compute for simpler background processing
 import 'package:flutter/foundation.dart';
 
 // Function to run in separate isolate
@@ -710,7 +745,8 @@ class _MyWidgetState extends State<MyWidget> {
       ),
     );
   }
-}`} lang="dart" title="Compute Function" />
+}
+```
 
 ---
 

--- a/src/content/docs/flutter/local-storage-databases.mdx
+++ b/src/content/docs/flutter/local-storage-databases.mdx
@@ -65,9 +65,11 @@ Your choice should balance performance needs, development speed, and data comple
 
 ### Basic Setup and Usage
 
-<Code code={`// pubspec.yaml
+```yaml
+// pubspec.yaml
 dependencies:
-  shared_preferences: ^2.2.0`} lang="yaml" />
+  shared_preferences: ^2.2.0
+```
 
 ```dart title="Storing Data"
 // Storing different data types
@@ -145,10 +147,12 @@ class PreferencesService {
 
 Hive is a lightweight, high-performance NoSQL database optimized for Flutter applications.
 
-<Code code={`// pubspec.yaml
+```yaml title="Dependencies"
+// pubspec.yaml
 dependencies:
   hive: ^2.2.3
-  hive_flutter: ^1.1.0`} lang="yaml" title="Dependencies" />
+  hive_flutter: ^1.1.0
+```
 
 ```dart title="Model Definition"
 import 'package:hive/hive.dart';
@@ -200,10 +204,12 @@ await taskBox.delete(id);          // Delete
 
 Drift is a reactive persistence library for Dart & Flutter applications that builds on top of SQLite.
 
-<Code code={`// pubspec.yaml
+```yaml title="Dependencies"
+// pubspec.yaml
 dependencies:
   drift: ^2.8.0
-  sqlite3_flutter_libs: ^0.5.15`} lang="yaml" title="Dependencies" />
+  sqlite3_flutter_libs: ^0.5.15
+```
 
 ```dart title="Database Setup"
 // Define table and database
@@ -227,7 +233,8 @@ class AppDatabase extends _\$AppDatabase {
 }
 ```
 
-<Code code={`// Reactive UI updates
+```dart title="Reactive UI"
+// Reactive UI updates
 StreamBuilder<List<Task>>(
   stream: database.watchAllTasks(),
   builder: (context, snapshot) {
@@ -245,7 +252,8 @@ StreamBuilder<List<Task>>(
       ),
     );
   },
-)`} lang="dart" title="Reactive UI" />
+)
+```
 
 ### Best Practices for Drift
 
@@ -256,19 +264,20 @@ StreamBuilder<List<Task>>(
 - Implement repository pattern to abstract database operations
 - Use transactions for related operations
 
-<Code code={`// Example of using transactions in Drift
+```dart title="Drift Transaction Example"
+// Example of using transactions in Drift
 Future<void> transferFunds(int fromAccount, int toAccount, double amount) {
   return database.transaction(() async {
     // Deduct from source account
     await (update(accounts)..where((a) => a.id.equals(fromAccount)))
       .write(AccountsCompanion(
-        balance: Expression.custom('balance - \$amount')
+        balance: Expression.custom('balance - $amount')
       ));
       
     // Add to destination account
     await (update(accounts)..where((a) => a.id.equals(toAccount)))
       .write(AccountsCompanion(
-        balance: Expression.custom('balance + \$amount')
+        balance: Expression.custom('balance + $amount')
       ));
       
     // Create transaction record
@@ -281,7 +290,8 @@ Future<void> transferFunds(int fromAccount, int toAccount, double amount) {
       )
     );
   });
-}`} lang="dart" title="Drift Transaction Example" />
+}
+```
 
 ---
 
@@ -289,12 +299,15 @@ Future<void> transferFunds(int fromAccount, int toAccount, double amount) {
 
 SQFlite provides direct access to SQLite functionality in Flutter applications.
 
-<Code code={`// pubspec.yaml
+```yaml title="Dependencies"
+// pubspec.yaml
 dependencies:
   sqflite: ^2.2.8+4
-  path: ^1.8.3`} lang="yaml" title="Dependencies" />
+  path: ^1.8.3
+```
 
-<Code code={`// Database helper singleton
+```dart
+// Database helper singleton
 class DatabaseHelper {
   static final DatabaseHelper instance = DatabaseHelper._init();
   static Database? _database;
@@ -380,7 +393,8 @@ Implementing effective offline capabilities ensures your app remains functional 
 
 <Tabs>
   <TabItem label="Basic Sync">
-    <Code code={`class BasicSyncService {
+```dart
+class BasicSyncService {
   final ApiService _api;
   final TaskRepository _repository;
   
@@ -402,19 +416,21 @@ Implementing effective offline capabilities ensures your app remains functional 
       }
     } catch (e) {
       // Handle connectivity issues
-      print('Sync failed: \$e');
+      print('Sync failed: $e');
     }
   }
-}`} lang="dart" />
+}
+```
 
-    **When to Use:**
+**When to Use:**
     - For simple data models
     - When conflicts are rare
     - For apps with limited offline editing
   </TabItem>
 
   <TabItem label="Timestamp-Based">
-    <Code code={`class TimestampSyncService {
+```dart
+class TimestampSyncService {
   final ApiService _api;
   final TaskRepository _repository;
   
@@ -444,16 +460,18 @@ Implementing effective offline capabilities ensures your app remains functional 
       // Handle sync errors
     }
   }
-}`} lang="dart" />
+}
+```
 
-    **When to Use:**
+**When to Use:**
     - For collaborative apps
     - When you need to track change history
     - For data with frequent updates
   </TabItem>
 
   <TabItem label="Queue-Based">
-    <Code code={`class QueueSyncService {
+```dart
+class QueueSyncService {
   final ApiService _api;
   final SyncQueueRepository _queueRepo;
   
@@ -512,9 +530,10 @@ Implementing effective offline capabilities ensures your app remains functional 
   bool _isServerError(Exception e) {
     // Determine if error is server-side (5xx) or client-side (4xx)
   }
-}`} lang="dart" />
+}
+```
 
-    **When to Use:**
+**When to Use:**
     - For mission-critical data
     - When order of operations matters
     - For apps with extensive offline functionality
@@ -549,7 +568,8 @@ As your app evolves, you may need to migrate from one storage solution to anothe
   5. **Cleanup** - Remove old storage system once migration is stable
 </Steps>
 
-<Code code={`// Migration service example
+```dart title="Migration Example"
+// Migration service example
 class StorageMigrationService {
   final SharedPreferences _prefs;
   final TaskRepository _hiveRepo;
@@ -571,10 +591,11 @@ class StorageMigrationService {
       // Mark as completed
       await _prefs.setBool('migration_completed', true);
     } catch (e) {
-      print('Migration failed: \$e');
+      print('Migration failed: $e');
     }
   }
-}`} lang="dart" title="Migration Example" />
+}
+```
 
 ---
 


### PR DESCRIPTION
## Description

Convert code components to Markdown fences to correct indentation.

## Type of Change

- [ ] Documentation improvement
- [ ] New documentation
- [ ] Bug fix (typo, broken link, etc.)
- [ ] Code example update
- [x] Other (Convert Code components to markdown fences to fix indentation)

## Checklist

- [x] I've tested my changes locally
- [x] All links work correctly
- [x] Code examples are tested and functional
- [x] Content follows the style guide
- [x] I've updated relevant sections
- [x] No spelling or grammar errors
- [x] Fixed MDX compilation errors
- [x] Maintained consistent formatting with other Flutter guides